### PR TITLE
Gives inline accordion the light utility class

### DIFF
--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -47,7 +47,7 @@
     {foreach from=$add.custom item=customGroup key=cgId} {* start of outer foreach *}
       {assign var="isAddressCustomPresent" value=1}
       {foreach from=$customGroup item=customValue key=cvId}
-        <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion" {if $customValue.collapse_display}{else}open{/if}>
+        <details id="address_custom_{$cgId}_{$locationIndex}" class="crm-address-custom-{$cgId}-{$locationIndex}-accordion crm-accordion-light" {if $customValue.collapse_display}{else}open{/if}>
           <summary class="collapsible-title">
             {$customValue.title}
           </summary>


### PR DESCRIPTION
Other custom field accordions on the contact dashboard use `.crm-accordion-light`.

Before
----------------------------------------
<img width="516" alt="image" src="https://github.com/lemniscus/civicrm-core/assets/1175967/b32759b0-d4df-46c7-8b5a-c7a489503f1d">

After
----------------------------------------
<img width="506" alt="image" src="https://github.com/lemniscus/civicrm-core/assets/1175967/b7d73f1a-3862-4159-8ddb-af3e9527b987">

Comments
----------------------------------------
NB - the size here still looks too big, relative to the other fields and how it looked before, because accordion headers are all 1rem/16px - which is a regularly suggested minimum size for accessibility.